### PR TITLE
fix: Docker runtime issues and empty-network crash

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/aleph_nodestatus/abi *.json

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-COPY ../ .
+COPY . .
 RUN pip wheel --no-cache-dir --wheel-dir /wheels .
 
 # Stage 2: Runtime (no compiler, no sources)
@@ -17,4 +17,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir /wheels/*.whl && rm -rf /wheels
+RUN rm -f /wheels/setuptools-*.whl && \
+    pip install --no-cache-dir /wheels/*.whl && \
+    rm -rf /wheels

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,10 @@ install_requires =
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 # python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 
+[options.package_data]
+aleph_nodestatus =
+    abi/*.json
+
 [options.packages.find]
 where = src
 exclude =

--- a/src/aleph_nodestatus/status.py
+++ b/src/aleph_nodestatus/status.py
@@ -661,11 +661,13 @@ async def process(dbs, window_size=None):
         ),
     ]
     nodes = None
+    resource_nodes = None
     async for height, nodes, resource_nodes in state_machine.process(iterators):
         pass
 
-    print("should set status")
-    await set_status(account, nodes, resource_nodes)
+    if nodes is not None:
+        print("should set status")
+        await set_status(account, nodes, resource_nodes)
 
     i = 0
     while True:


### PR DESCRIPTION
## Summary
- **setuptools/pkg_resources**: `pip wheel` pulls in setuptools 82+ which removed `pkg_resources`. The wheel was overwriting the base image's working setuptools 79. Fix: delete `setuptools-*.whl` before installing.
- **ABI files missing**: `include_package_data` relies on git for file discovery, but `.git` is excluded from the Docker build context. Fix: add explicit `[options.package_data]` in setup.cfg and a `MANIFEST.in`.
- **Empty-network crash**: `resource_nodes` was never initialized before the `async for` loop in `process()`. On an empty network the iterator yields nothing, causing `UnboundLocalError` at the `set_status` call. Fix: initialize to `None` and guard the call.
- **COPY path**: `COPY ../ .` doesn't work when the build context is the repo root. Fixed to `COPY . .`.

## Test plan
- [x] `docker build --no-cache -f docker/Dockerfile -t alephim/nodestatus:latest .` succeeds
- [x] `docker run --rm alephim/nodestatus:latest python -c "import pkg_resources"` works
- [x] ABI JSON files present in image under `site-packages/aleph_nodestatus/abi/`
- [ ] Verify nodestatus starts on an empty testnet without crashing