### PR TITLE
Distribute hold-tier execution rewards from the incentives pool

### DIFF
--- a/src/aleph_nodestatus/commands.py
+++ b/src/aleph_nodestatus/commands.py
@@ -303,7 +303,7 @@ async def process_credit_distribution(
                     hi = mid - 1
             end_block = lo
 
-    rewards, total_storage, total_execution, total_dev_fund = (
+    rewards, total_storage, total_execution, total_hold_rewards, total_dev_fund = (
         await prepare_credit_distribution(
             dbs, end_block, start_time, end_time, full_resync=full_resync
         )
@@ -329,6 +329,7 @@ async def process_credit_distribution(
         tags=tags,
         storage_total_aleph=total_storage,
         execution_total_aleph=total_execution,
+        hold_rewards_total_aleph=total_hold_rewards,
         dev_fund_total_aleph=total_dev_fund,
         full_resync=full_resync,
     )
@@ -345,6 +346,7 @@ async def process_credit_distribution(
     print(f"Time range: {start_time} -> {end_time}")
     print(f"Storage expenses: {total_storage:,.4f} ALEPH")
     print(f"Execution expenses: {total_execution:,.4f} ALEPH")
+    print(f"Hold rewards (incentives pool): {total_hold_rewards:,.4f} ALEPH")
     print(f"Dev fund ({settings.credit_dev_fund_share:.0%}): {total_dev_fund:,.4f} ALEPH")
     print(f"Total recipients: {len(rewards)}")
     print(f"Total rewards: {total_rewards:,.4f} ALEPH")

--- a/src/aleph_nodestatus/credit_distribution.py
+++ b/src/aleph_nodestatus/credit_distribution.py
@@ -247,23 +247,23 @@ def _get_reward_address(node, web3=None):
 
 
 def _distribute_expense(expense_type, expense, nodes, resource_nodes,
-                         rewards, web3=None):
+                         payouts, web3=None):
     """
     Distribute a single expense message using the current node state.
 
-    ALEPH cost per credit entry = credit["amount"] * expense["credit_price_aleph"]
-    (credit["price"] is the compute rate, NOT the ALEPH cost)
+    ALEPH cost per entry = entry["amount"] * expense["credit_price_aleph"]
+    (entry["price"] is the compute rate, NOT the ALEPH cost)
 
-    Mutates `rewards` in place.
-    Returns (storage_aleph, execution_aleph, dev_fund_aleph) totals.
+    Two entry pools are processed with the SAME split:
+    - `credits`: user paid in credits (revenue from users)
+    - `rewards`: holder-tier executions (paid from the incentives pool, not
+      deducted from any user). Execution messages only; gated by
+      settings.credit_hold_rewards_enabled.
+
+    Mutates `payouts` in place (address -> ALEPH owed).
+    Returns (storage_aleph, execution_aleph, hold_rewards_aleph, dev_fund_aleph).
     """
     credit_price_aleph = expense.get("credit_price_aleph", 0)
-    total_aleph = sum(
-        credit["amount"] * credit_price_aleph
-        for credit in expense.get("credits", [])
-    )
-
-    dev_fund = total_aleph * settings.credit_dev_fund_share
 
     if expense_type == "storage":
         ccn_share = settings.credit_storage_ccn_share
@@ -272,24 +272,6 @@ def _distribute_expense(expense_type, expense, nodes, resource_nodes,
         ccn_share = settings.credit_execution_ccn_share
         staker_share = settings.credit_execution_staker_share
 
-        # CRN share to the specific CRN per credit
-        for credit in expense.get("credits", []):
-            credit_aleph = credit["amount"] * credit_price_aleph
-            node_id = credit.get("node_id")
-            if node_id and node_id in resource_nodes:
-                rnode = resource_nodes[node_id]
-                addr = _get_reward_address(rnode, web3)
-                rewards[addr] = (
-                    rewards.get(addr, 0)
-                    + credit_aleph * settings.credit_execution_crn_share
-                )
-            elif node_id:
-                LOGGER.warning(
-                    f"CRN {node_id} not found in resource_nodes, "
-                    f"skipping CRN share"
-                )
-
-    # --- CCN pool (weighted by score) ---
     ccn_weights = {}
     for node_hash, node in nodes.items():
         if node["status"] != "active":
@@ -300,17 +282,8 @@ def _distribute_expense(expense_type, expense, nodes, resource_nodes,
                 "score": score,
                 "reward_address": _get_reward_address(node, web3),
             }
-
     total_ccn_score = sum(v["score"] for v in ccn_weights.values())
-    ccn_pool = total_aleph * ccn_share
 
-    if total_ccn_score > 0 and ccn_pool > 0:
-        for info in ccn_weights.values():
-            share = info["score"] / total_ccn_score
-            addr = info["reward_address"]
-            rewards[addr] = rewards.get(addr, 0) + ccn_pool * share
-
-    # --- Staker pool ---
     all_stakers = {}
     for node in nodes.values():
         if node["status"] != "active":
@@ -319,17 +292,57 @@ def _distribute_expense(expense_type, expense, nodes, resource_nodes,
             all_stakers[addr] = all_stakers.get(addr, 0) + amount
     total_staked = sum(all_stakers.values())
 
-    staker_pool = total_aleph * staker_share
+    def apply_split(entries):
+        total = sum(e["amount"] * credit_price_aleph for e in entries)
+        dev = total * settings.credit_dev_fund_share
 
-    if total_staked > 0 and staker_pool > 0:
-        for addr, staked in all_stakers.items():
-            share = staked / total_staked
-            rewards[addr] = rewards.get(addr, 0) + staker_pool * share
+        if expense_type == "execution":
+            for entry in entries:
+                entry_aleph = entry["amount"] * credit_price_aleph
+                node_id = entry.get("node_id")
+                if node_id and node_id in resource_nodes:
+                    rnode = resource_nodes[node_id]
+                    addr = _get_reward_address(rnode, web3)
+                    payouts[addr] = (
+                        payouts.get(addr, 0)
+                        + entry_aleph * settings.credit_execution_crn_share
+                    )
+                elif node_id:
+                    LOGGER.warning(
+                        f"CRN {node_id} not found in resource_nodes, "
+                        f"skipping CRN share"
+                    )
+
+        ccn_pool = total * ccn_share
+        if total_ccn_score > 0 and ccn_pool > 0:
+            for info in ccn_weights.values():
+                share = info["score"] / total_ccn_score
+                addr = info["reward_address"]
+                payouts[addr] = payouts.get(addr, 0) + ccn_pool * share
+
+        staker_pool = total * staker_share
+        if total_staked > 0 and staker_pool > 0:
+            for addr, staked in all_stakers.items():
+                share = staked / total_staked
+                payouts[addr] = payouts.get(addr, 0) + staker_pool * share
+
+        return total, dev
+
+    credits_total, credits_dev = apply_split(expense.get("credits", []))
+
+    hold_total = 0
+    hold_dev = 0
+    if expense_type == "execution" and settings.credit_hold_rewards_enabled:
+        hold_entries = expense.get("rewards", [])
+        if hold_entries:
+            hold_total, hold_dev = apply_split(hold_entries)
+
+    dev_fund_total = credits_dev + hold_dev
 
     if expense_type == "storage":
-        return total_aleph, 0, dev_fund
+        return credits_total, 0, 0, dev_fund_total
     else:
-        return 0, total_aleph, dev_fund
+        return 0, credits_total, hold_total, dev_fund_total
 
 
 async def prepare_credit_distribution(dbs, end_height, start_time, end_time,
@@ -342,7 +355,10 @@ async def prepare_credit_distribution(dbs, end_height, start_time, end_time,
     machine from genesis instead.
 
     Returns:
-        Tuple of (rewards, total_storage_aleph, total_execution_aleph, total_dev_fund_aleph)
+        Tuple of (payouts, total_storage_aleph, total_execution_aleph,
+                  total_hold_rewards_aleph, total_dev_fund_aleph).
+        `total_hold_rewards_aleph` is sourced from the incentives pool, not
+        from user credits, and must not be netted against user expenses.
     """
     api_server = PublishMode.get_publish_api_server()
 
@@ -353,7 +369,7 @@ async def prepare_credit_distribution(dbs, end_height, start_time, end_time,
 
     if not expenses:
         LOGGER.warning("No credit expenses found in the given time range")
-        return {}, 0, 0, 0
+        return {}, 0, 0, 0, 0
 
     if full_resync:
         web3 = get_web3()
@@ -386,9 +402,10 @@ async def _prepare_with_snapshots(api_server, start_time, end_time,
 
     snapshot_heights = [s[0] for s in snapshots]
 
-    rewards = {}
+    payouts = {}
     total_storage = 0
     total_execution = 0
+    total_hold_rewards = 0
     total_dev_fund = 0
 
     for exp_height, exp_type, expense in expenses:
@@ -399,22 +416,24 @@ async def _prepare_with_snapshots(api_server, start_time, end_time,
 
         _, nodes, resource_nodes = snapshots[idx]
 
-        s, e, d = _distribute_expense(
-            exp_type, expense, nodes, resource_nodes, rewards, web3=web3
+        s, e, h, d = _distribute_expense(
+            exp_type, expense, nodes, resource_nodes, payouts, web3=web3
         )
         total_storage += s
         total_execution += e
+        total_hold_rewards += h
         total_dev_fund += d
 
     LOGGER.info(
         f"Credit distribution (snapshots): "
         f"{total_storage:.4f} ALEPH storage, "
         f"{total_execution:.4f} ALEPH execution, "
+        f"{total_hold_rewards:.4f} ALEPH hold rewards (incentives pool), "
         f"{total_dev_fund:.4f} ALEPH dev fund (not distributed), "
-        f"{sum(rewards.values()):.4f} ALEPH total distributed"
+        f"{sum(payouts.values()):.4f} ALEPH total distributed"
     )
 
-    return rewards, total_storage, total_execution, total_dev_fund
+    return payouts, total_storage, total_execution, total_hold_rewards, total_dev_fund
 
 
 async def _prepare_with_state_machine(dbs, end_height, expenses, web3):
@@ -467,9 +486,10 @@ async def _prepare_with_state_machine(dbs, end_height, expenses, web3):
         ),
     ]
 
-    rewards = {}
+    payouts = {}
     total_storage = 0
     total_execution = 0
+    total_hold_rewards = 0
     total_dev_fund = 0
     expense_idx = 0
     nodes = None
@@ -481,11 +501,12 @@ async def _prepare_with_state_machine(dbs, end_height, expenses, web3):
 
         while expense_idx < len(expenses) and expenses[expense_idx][0] <= height:
             exp_height, exp_type, expense = expenses[expense_idx]
-            s, e, d = _distribute_expense(
-                exp_type, expense, nodes, resource_nodes, rewards, web3=web3
+            s, e, h, d = _distribute_expense(
+                exp_type, expense, nodes, resource_nodes, payouts, web3=web3
             )
             total_storage += s
             total_execution += e
+            total_hold_rewards += h
             total_dev_fund += d
             expense_idx += 1
 
@@ -499,11 +520,12 @@ async def _prepare_with_state_machine(dbs, end_height, expenses, web3):
                 )
                 expense_idx += 1
                 continue
-            s, e, d = _distribute_expense(
-                exp_type, expense, nodes, resource_nodes, rewards, web3=web3
+            s, e, h, d = _distribute_expense(
+                exp_type, expense, nodes, resource_nodes, payouts, web3=web3
             )
             total_storage += s
             total_execution += e
+            total_hold_rewards += h
             total_dev_fund += d
             expense_idx += 1
 
@@ -514,8 +536,9 @@ async def _prepare_with_state_machine(dbs, end_height, expenses, web3):
         f"Credit distribution (full resync): "
         f"{total_storage:.4f} ALEPH storage, "
         f"{total_execution:.4f} ALEPH execution, "
+        f"{total_hold_rewards:.4f} ALEPH hold rewards (incentives pool), "
         f"{total_dev_fund:.4f} ALEPH dev fund (not distributed), "
-        f"{sum(rewards.values()):.4f} ALEPH total distributed"
+        f"{sum(payouts.values()):.4f} ALEPH total distributed"
     )
 
-    return rewards, total_storage, total_execution, total_dev_fund
+    return payouts, total_storage, total_execution, total_hold_rewards, total_dev_fund

--- a/src/aleph_nodestatus/settings.py
+++ b/src/aleph_nodestatus/settings.py
@@ -104,6 +104,11 @@ class Settings(BaseSettings):
     # Dev fund (not distributed, tracked for accounting)
     credit_dev_fund_share: float = 0.05
 
+    # Route upstream `rewards` entries (holder-tier executions, paid from the
+    # incentives pool rather than deducted from users) through the same split
+    # as `credits`. Upstream tagged this @temporary — disable to ignore.
+    credit_hold_rewards_enabled: bool = True
+
     crn_inactivity_threshold_days: int = 90
     crn_inactivity_cutoff_height: int = 20840959
 


### PR DESCRIPTION
## Summary

Upstream aleph-api-credit PR #5 (`feat/hold-execution-rewards`) adds an optional `rewards` array to `aleph_credit_expense` execution messages for holder-tier instances — the user paid by holding ALEPH, not by burning credits. Node operators should still be paid for running these workloads, but from the incentives pool rather than from user revenue.

- Parse the new `rewards` entries alongside existing `credits` in `aleph_credit_expense` execution messages.
- Route them through the same 60/15/20/5 split (CRN / CCN / stakers / dev fund).
- Surface the new total separately as `hold_rewards_total_aleph` in the published `credit-rewards-distribution` post so accounting can distinguish user-paid from incentives-pool-paid payouts.
- Gated by `credit_hold_rewards_enabled` (default `true`), mirroring the upstream `@temporary` `JOB_EXPENSE_HOLD_ENABLED` flag.
- Rename the inner accumulator from `rewards` to `payouts` to free the name for the new message field.

## Test plan

- [ ] Dry-run `nodestatus-distribute` on testnet against messages that contain `rewards` and verify the summary shows the split correctly.
- [ ] Confirm pre-PR-5 messages (no `rewards` field) produce identical numbers to the previous behavior.
- [ ] Toggle `credit_hold_rewards_enabled=false` and verify `hold_rewards_total_aleph` is 0 and the field is still present in the post.
- [ ] Run the existing test suite (`pytest`).