### PR TITLE
fix: deterministic intra-block ordering of state-machine events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/*
 .settings
 .idea
 tags
+.worktrees/
 
 # Package files
 *.egg

--- a/src/aleph_nodestatus/status.py
+++ b/src/aleph_nodestatus/status.py
@@ -1,5 +1,4 @@
 import asyncio
-import random
 from collections import deque
 from urllib.parse import urlparse
 from multiaddr import Multiaddr
@@ -35,7 +34,17 @@ EDITABLE_FIELDS = [
 
 async def prepare_items(item_type, iterator):
     async for height, item in iterator:
-        yield (height, random.random(), (item_type, item))
+        # Tiebreaker for items sharing a block height. For Aleph messages, prefer
+        # the inner content.time (when the user signed) over the envelope time, and
+        # use item_hash as a final deterministic tiebreaker. Non-message items
+        # (balance/contract tuples) sort first with (0, "").
+        if isinstance(item, dict):
+            inner = item.get("content") if isinstance(item.get("content"), dict) else None
+            msg_time = (inner or {}).get("time", item.get("time")) or 0
+            tiebreak = (msg_time, item.get("item_hash", ""))
+        else:
+            tiebreak = (0, "")
+        yield (height, tiebreak, (item_type, item))
         
 def is_block_in_discarded_scores_range(height):
     for start, end in settings.scores_discard_periods:

--- a/tests/test_prepare_items_ordering.py
+++ b/tests/test_prepare_items_ordering.py
@@ -1,0 +1,72 @@
+"""
+Regression test for the link-ordering bug.
+
+Previously `prepare_items` used `random.random()` as the tiebreaker within a block,
+so several `corechan-operation` messages confirmed in the same Ethereum block would
+be processed in a random order on every run. When a `link` op happened to be merged
+ahead of its `create-node`, the link's precondition (`address in self.address_nodes`)
+failed and the link was silently dropped — non-deterministically wiping CCN/CRN
+linkage on each replay.
+
+The fix: tiebreak deterministically on (message_time, item_hash).
+"""
+import asyncio
+
+from aleph_nodestatus.status import prepare_items
+from aleph_nodestatus.utils import merge
+
+
+async def _async_iter(items):
+    for it in items:
+        yield it
+
+
+# Reproduces the Apicultor incident: 7 corechan-operation messages all at the same
+# Ethereum block, ordered correctly by their content.time.
+HEIGHT = 24_992_406
+APICULTOR_OPS = [
+    {"item_hash": "crn2_create",  "time": 1.0, "content": {"time": 1_777_536_288, "address": "0x21801"}},
+    {"item_hash": "crni_create",  "time": 1.0, "content": {"time": 1_777_536_353, "address": "0x21801"}},
+    {"item_hash": "crn12_create", "time": 1.0, "content": {"time": 1_777_536_630, "address": "0x21801"}},
+    {"item_hash": "ccn_create",   "time": 1.0, "content": {"time": 1_777_537_218, "address": "0xd144f"}},
+    {"item_hash": "link_crn2",    "time": 1.0, "content": {"time": 1_777_537_490, "address": "0xd144f"}},
+    {"item_hash": "link_crni",    "time": 1.0, "content": {"time": 1_777_537_503, "address": "0xd144f"}},
+    {"item_hash": "link_crn12",   "time": 1.0, "content": {"time": 1_777_537_526, "address": "0xd144f"}},
+]
+
+
+async def _drain():
+    """Reproduces the real call site: each message comes from its own
+    iterator-window, all merged together. With N>1 iterators sharing a height,
+    the heap-merge tiebreaker decides ordering."""
+    iterators = [
+        prepare_items("staking-update", _async_iter([(HEIGHT, msg)]))
+        for msg in APICULTOR_OPS
+    ]
+    return [item for _, _, (_, item) in
+            [tup async for tup in merge(*iterators)]]
+
+
+def test_prepare_items_orders_deterministically_within_block():
+    """Same input yields the same output on every run."""
+    runs = [asyncio.run(_drain()) for _ in range(20)]
+    first = [m["item_hash"] for m in runs[0]]
+    for r in runs[1:]:
+        assert [m["item_hash"] for m in r] == first, (
+            "prepare_items + merge produced different orderings across runs — "
+            "tiebreaker is not deterministic"
+        )
+
+
+def test_prepare_items_orders_create_before_link_within_block():
+    """The CCN's create-node must be merged before any link op referencing it,
+    even though they share an Ethereum block. Determinism alone isn't enough —
+    the order must respect message content.time."""
+    out = asyncio.run(_drain())
+    order = [m["item_hash"] for m in out]
+    ccn_idx = order.index("ccn_create")
+    for link in ("link_crn2", "link_crni", "link_crn12"):
+        assert order.index(link) > ccn_idx, (
+            f"{link} merged before ccn_create — link precondition would fail "
+            f"and the linkage would be silently dropped"
+        )


### PR DESCRIPTION
## Summary

`prepare_items` (`src/aleph_nodestatus/status.py`) used `random.random()` as the
tiebreaker for items sharing an Ethereum block height. The downstream `merge`
heap orders by tuple, so corechan-operation messages confirmed in the same
block were processed in a different order on every replay. When a `link` op
happened to merge before its `create-node`, the link's precondition
(`address in self.address_nodes`) failed and the op was silently dropped — and
the next aggregate publication overwrote previously-correct linkage with the
broken state.

This is the bug that wiped Apicultor's three CRN links in last week's
aggregates: links applied correctly at 10:27 UTC, then a state-machine
restart re-rolled the random ordering, and all three CRNs reverted to
`status: waiting` for ~37 hours until the next restart got a lucky shuffle.

## Fix

Replace the random tiebreaker with a deterministic one:

- For Aleph messages, key on the inner `content.time` (when the user signed)
  with a fallback to the envelope `time`, and use `item_hash` as the final
  tiebreaker for fully-deterministic ordering.
- Non-message items (balance / contract-event tuples) sort first with `(0, "")`.

For the Apicultor incident, this places the CCN's `create-node` (signed at
10:20 UTC) ahead of the three `link` ops (signed at 10:24-10:25 UTC) on every
replay, so the precondition is always satisfied.

## Why content.time over envelope time

The envelope `time` is when the message arrived at the Aleph network; the
inner `content.time` is when the user signed. The signed time is the
authoritative ordering for ops within a single Ethereum confirmation block.

## Tests

`tests/test_prepare_items_ordering.py` reproduces the Apicultor incident:
seven `corechan-operation` messages at the same height, each from its own
iterator window (matching the production call shape).

- `test_prepare_items_orders_deterministically_within_block` — same input
  yields the same output across 20 runs.
- `test_prepare_items_orders_create_before_link_within_block` — `ccn_create`
  is merged before all three `link_*` ops.

Both tests fail against the previous random tiebreaker (the second one
caught a run with `link_crni` ahead of `ccn_create` — exactly the production
failure) and pass with this fix.

## Notes

This branch also includes a small commit adding `.worktrees/` to `.gitignore`
(needed locally for the worktree-based dev workflow).

## Test plan

- [x] New tests fail on `main`, pass on this branch
- [ ] Run a state-machine replay against current `corechan-operation` history
      and diff the resulting aggregate against the most recent on-chain
      aggregate to confirm no regression on existing nodes/links