### PR TITLE
Feat/credit distribution v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/*
 .settings
 .idea
 tags
+.worktrees/
 
 # Package files
 *.egg

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       # strips from job execution. Must exist on the host or Docker creates an
       # empty directory here instead.
       - ./.env.extract:/aleph-nodestatus/.env:ro
+      # Shared lock dir so flock is visible across all three containers
+      # (each container's /tmp is private; a named volume is not).
+      - ns-locks:/locks
     # Maps `host.docker.internal` to the host's bridge gateway IP so
     # fork-mode dry-runs (`--fork-rpc=http://host.docker.internal:8545`
     # targeting a local Anvil) work on Linux hosts, not just Docker
@@ -30,7 +33,11 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    command: /bin/bash -c "echo '0 * * * * cd /aleph-nodestatus && /usr/local/bin/nodestatus-extract-credits --act -v >> /proc/1/fd/1 2>&1' | crontab - && service cron start && /bin/sh"
+    # `flock -n` guards against overlapping runs: if a previous extract is
+    # still broadcasting when the next hour fires, cron would otherwise start
+    # a second concurrent process (double extraction + doubled memory). -n
+    # makes the new run exit immediately instead of stacking.
+    command: /bin/bash -c "echo '0 * * * * cd /aleph-nodestatus && /usr/bin/flock -n /locks/ns-extract.lock /usr/local/bin/nodestatus-extract-credits --act -v >> /proc/1/fd/1 2>&1' | crontab - && service cron start && /bin/sh"
 
   # Hourly calculation snapshots for the new credit-rewards flow.
   # ethereum_pkey here must be status_sender's.
@@ -49,6 +56,8 @@ services:
       # See note on nodestatus-extract: per-service config mounted as the
       # project-root .env that pydantic loads.
       - ./.env.calc:/aleph-nodestatus/.env:ro
+      # Shared with nodestatus-dist so their flock lock is mutually visible.
+      - ns-locks:/locks
     # See note on nodestatus-extract — kept on all three services for
     # consistency so operators don't have to remember which one needs it.
     extra_hosts:
@@ -58,7 +67,15 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    command: /bin/bash -c "echo '0 * * * * cd /aleph-nodestatus && /usr/local/bin/nodestatus-distribute-credits -v >> /proc/1/fd/1 2>&1' | crontab - && service cron start && /bin/sh"
+    # Hourly calc recomputes the whole [last_distribution .. now] window,
+    # which grows for up to 10 days; the aggregate/expense API queries are
+    # slow, so a single run's wall-time can exceed one hour as the window
+    # fills. Without a guard, cron then starts a second (and third) full-
+    # window run on top of the first — the memory blow-up. `flock -n` on a
+    # lock SHARED with nodestatus-dist (via the ns-locks volume) means: skip
+    # this calc if any distribute run (calc or the real --act dist) is already
+    # in flight, so two heavy computations never coexist.
+    command: /bin/bash -c "echo '0 * * * * cd /aleph-nodestatus && /usr/bin/flock -n /locks/ns-distribute.lock /usr/local/bin/nodestatus-distribute-credits -v >> /proc/1/fd/1 2>&1' | crontab - && service cron start && /bin/sh"
 
   # Distribution every 10 days. ethereum_pkey here must be
   # distribution_recipient's and the address must hold >= the expected
@@ -78,6 +95,8 @@ services:
       # See note on nodestatus-extract: per-service config mounted as the
       # project-root .env that pydantic loads.
       - ./.env.dist:/aleph-nodestatus/.env:ro
+      # Shared with nodestatus-calc so their flock lock is mutually visible.
+      - ns-locks:/locks
     # See note on nodestatus-extract.
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -86,4 +105,16 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    command: /bin/bash -c "echo '0 0 */10 * * cd /aleph-nodestatus && /usr/local/bin/nodestatus-distribute-credits --act -v >> /proc/1/fd/1 2>&1' | crontab - && service cron start && /bin/sh"
+    # Shares /locks/ns-distribute.lock with nodestatus-calc (via the ns-locks
+    # named volume), but takes the lock in BLOCKING mode (no -n): the real
+    # distribution must never be skipped, so if an hourly calc happens to be
+    # running when the 10-day tick fires, dist waits for it to release the
+    # lock and then runs. Its own cadence guard (credit_dist_min_interval_blocks)
+    # still protects against mis-fires.
+    command: /bin/bash -c "echo '0 0 */10 * * cd /aleph-nodestatus && /usr/bin/flock /locks/ns-distribute.lock /usr/local/bin/nodestatus-distribute-credits --act -v >> /proc/1/fd/1 2>&1' | crontab - && service cron start && /bin/sh"
+
+# Small named volume holding only flock lockfiles. Shared across the three
+# services so a run in one container is visible to the guards in the others
+# (each container's /tmp is private, which is why a shared volume is needed).
+volumes:
+  ns-locks:

--- a/src/aleph_nodestatus/commands.py
+++ b/src/aleph_nodestatus/commands.py
@@ -856,13 +856,23 @@ async def process_credit_distribution(
             "threshold_days": settings.credit_dist_slash_threshold_days,
             "retroactive": settings.credit_dist_slash_retroactive,
             "streams": list(enabled_slash_streams()) if slash_on else [],
+            # Sum of the `slashed` map — the total nominally withheld,
+            # matching the per-node `nodes` amounts below.
+            "total_aleph": sum(slashed.values()),
             "nodes": slashed_meta_nodes,
         },
         "credit_revenue_totals": credit_totals,
         "holder_tier_totals": {**holder_totals,
                                 "included": flags.get("holder_tier", False)},
         "wage_subsidy": wage_totals,
+        # `total` is the GROSS calculation (sums `rewards`, includes slashed
+        # amounts) and mirrors aleph-api-credit's total block — kept for
+        # parity. `payout_total_aleph` is the NET actually transferred on
+        # chain (sum of the post-slash, floored, zero-dropped payout), so it
+        # equals the sum of `targets[]`. The two differ by the withheld slash:
+        # payout_total_aleph == total.totals.aleph - (effective slash).
         "total": build_total_summary(final_rewards, by_address_detailed),
+        "payout_total_aleph": sum(payout_rewards.values()),
         "feature_flags": flags,
         "tags": [status, "credits", settings.filter_tag],
         "sources": transfer_metadata["sources"],

--- a/src/aleph_nodestatus/commands.py
+++ b/src/aleph_nodestatus/commands.py
@@ -361,6 +361,21 @@ def nonce_gap_reason(current_nonce, last_content, get_tx_nonce=None):
     return None
 
 
+def signer_next_nonce(web3, sender):
+    """Signer's next usable nonce, counting PENDING (unmined) transactions.
+
+    Reads with block_identifier='pending', not web3's default 'latest'. The
+    double-pay case the nonce-continuity guard exists to catch is a
+    batchTransfer a prior run broadcast but that has not yet mined (the run
+    crashed before publishing). 'latest' counts only mined txs, so it would
+    hide that pending tx and let a rerun re-broadcast the same payouts;
+    'pending' includes it so `nonce_gap_reason` sees the gap and aborts.
+    """
+    return web3.eth.get_transaction_count(
+        web3.to_checksum_address(sender), "pending"
+    )
+
+
 async def process_credit_distribution(
     start_height, end_height, *,
     act=False, dry_run=False, force=False, force_cap=False,
@@ -696,9 +711,7 @@ async def process_credit_distribution(
         # operator reconciles manually and reruns with --force-nonce-gap.
         # Skipped in fork mode (the fork account nonce isn't the prod cursor).
         if not fork_rpc:
-            current_nonce = web3.eth.get_transaction_count(
-                web3.to_checksum_address(sender)
-            )
+            current_nonce = signer_next_nonce(web3, sender)
 
             # Older distribution posts recorded only the batch tx hash, not the
             # nonce. Recover the nonce on-chain from that hash so the guard works
@@ -1338,10 +1351,11 @@ def _parse_amount_kv(values, *, flag_name: str, configured_symbols: set):
                    "stay within their ceilings; leftover stays in the contract "
                    "for the next cron cycle so the pool can rebalance via "
                    "arbitrage between swaps. Overrides "
-                   "settings.extract_max_price_impact_bps (default 200). "
-                   "Sizing always runs for swap tokens; to disable only the "
-                   "Credit-API deviation half, set "
-                   "extract_price_deviation_enabled=False.")
+                   "settings.extract_max_price_impact_bps (default 200) when "
+                   "given; 0 means zero-tolerance (only a zero-impact swap "
+                   "passes), not disabled. Sizing always runs for swap "
+                   "tokens; to disable only the Credit-API deviation half, "
+                   "set extract_price_deviation_enabled=False.")
 @click.option("--fork-rpc", "fork_rpc", default=None,
               help="URL of a local mainnet fork (e.g. http://localhost:8545 "
                    "for `anvil --fork-url …`). Requires --dry-run; refused "
@@ -1466,10 +1480,11 @@ def extract_credits(verbose, act, dry_run, no_transfer, immediate,
         tokens=tuple(tokens),
         max_amounts=max_amounts,
         min_amounts=min_amounts,
-        max_price_impact_bps=(
-            max_price_impact_bps if max_price_impact_bps is not None
-            else settings.extract_max_price_impact_bps
-        ),
+        # Pass the raw CLI value through: None (unset) resolves to
+        # settings.extract_max_price_impact_bps inside extract_aleph, while an
+        # explicit 0 survives as a real zero-tolerance ceiling instead of being
+        # coerced back to the default.
+        max_price_impact_bps=max_price_impact_bps,
         fork_rpc=resolved_fork_rpc,
         reconcile_bps=(
             reconcile_bps if reconcile_bps is not None

--- a/src/aleph_nodestatus/credit_distribution.py
+++ b/src/aleph_nodestatus/credit_distribution.py
@@ -859,6 +859,22 @@ def zero_totals():
             "unallocated_staker_by_id":     {}}
 
 
+def _expense_version(expense):
+    """Best-effort numeric `expense.version`; defaults to 1 (v1).
+
+    v2 producers emit `version: 2` as a JSON number (the TS emitter
+    even gates on `typeof version === "number"`). A numeric string is
+    coerced — matching how the JS `>=` in the TS port would compare it
+    at runtime — and anything non-numeric falls back to v1: this feeds
+    an observability-only check, which must never abort a distribution
+    run over a malformed envelope field.
+    """
+    try:
+        return float(expense.get("version") or 1)
+    except (TypeError, ValueError):
+        return 1
+
+
 def _validate_hold_aggregates(expense):
     """Cross-check the declared hold aggregates against `expense.hold[]`.
 
@@ -866,16 +882,31 @@ def _validate_hold_aggregates(expense):
     2026-05 by aleph-api-credit) when present, otherwise falls back to
     the legacy top-level `hold_count` / `hold_amount` keys still
     present on pre-migration messages.
+
+    v2 storage expenses (`expense.version >= 2`) aggregate `hold[]` per
+    ADDRESS while `stats.hold.count` keeps per-FILE semantics, so the
+    comparable actual is the sum of the per-entry `count` fields rather
+    than the number of entries (mirrors computeRewards.ts in
+    aleph-api-credit). A v2 entry with a missing or non-numeric `count`
+    contributes 0 and the resulting under-count keeps the warning —
+    observability only.
     """
     stats_hold = (expense.get("stats") or {}).get("hold") or {}
     declared_count = stats_hold.get("count", expense.get("hold_count"))
     declared_amount = stats_hold.get("amount", expense.get("hold_amount"))
 
     hold = expense.get("hold", [])
-    if declared_count is not None and declared_count != len(hold):
+    if _expense_version(expense) >= 2:
+        actual_count = sum(
+            h["count"] if isinstance(h.get("count"), (int, float)) else 0
+            for h in hold
+        )
+    else:
+        actual_count = len(hold)
+    if declared_count is not None and declared_count != actual_count:
         LOGGER.warning(
             f"hold count mismatch: declared={declared_count}, "
-            f"actual={len(hold)}"
+            f"actual={actual_count}"
         )
     if declared_amount is not None:
         actual = sum(h.get("amount", 0) for h in hold)

--- a/src/aleph_nodestatus/credit_distribution.py
+++ b/src/aleph_nodestatus/credit_distribution.py
@@ -882,10 +882,19 @@ def _parse_message(msg):
     return None, None, None
 
 
-def _project_expense(expense, src_key):
-    """Synthesize an expense with the chosen list aliased as credits[]."""
+def _project_expense(expense, src_key, price_multiplier=1.0):
+    """Synthesize an expense with the chosen list aliased as credits[].
+
+    `price_multiplier` scales `credit_price_aleph`, which scales the whole
+    projected pool (`total_aleph = Σ amount × price`). Used to dial the
+    holder_tier stream down without disabling it — applying it at the price
+    keeps every downstream figure (rewards, totals, detailed AND the slash
+    accumulator) consistently scaled.
+    """
     return {
-        "credit_price_aleph": expense.get("credit_price_aleph", 0),
+        "credit_price_aleph": (
+            expense.get("credit_price_aleph", 0) * price_multiplier
+        ),
         "credits":            expense.get(src_key, []),
     }
 
@@ -1258,7 +1267,10 @@ def _apply_expenses_to_snapshots(
             _apply_expense_to(
                 holder_rewards, holder_totals, holder_detailed,
                 holder_unallocated, exp_type,
-                _project_expense(expense, "hold"),
+                _project_expense(
+                    expense, "hold",
+                    price_multiplier=settings.credit_dist_holder_tier_pct / 100.0,
+                ),
                 nodes, resource_nodes, web3,
                 accumulator=accumulator, stream="holder_tier",
             )

--- a/src/aleph_nodestatus/credit_distribution.py
+++ b/src/aleph_nodestatus/credit_distribution.py
@@ -424,6 +424,58 @@ async def _iter_posts_dedup(client, post_filter, last_end_height=None):
             break
 
 
+# How many extra 1-day windows to walk back looking for a boundary
+# snapshot (latest aggregate with ts <= start_time) when the default
+# 1-day lookback comes back empty — e.g. after a corechannel publisher
+# outage. Mirrors aleph-api-credit `snapshotsStore.loadSnapshotsForRange`
+# (30-iteration day-by-day walk-back).
+_SNAPSHOT_BOUNDARY_LOOKBACK_DAYS = 30
+
+
+async def _fetch_snapshots_between(client, sender, window_start, window_end):
+    """Fetch corechannel aggregate snapshots with msg.time in the window.
+
+    Returns a list of (ts, nodes_dict, resource_nodes_dict, item_hash),
+    unsorted. Skips non-corechannel aggregates, unconfirmed messages and
+    entries without a usable timestamp.
+    """
+    # SDK 1.4.0 rejects bare `int` in start_date/end_date; cast to float.
+    message_filter = MessageFilter(
+        message_types=[MessageType.aggregate],
+        addresses=[sender],
+        start_date=float(window_start),
+        end_date=float(window_end),
+    )
+
+    # AGGREGATE messages on Aleph wrap their body in two `content` layers:
+    #   msg["content"] = {"key": "<name>", "content": {<body>}, ...}
+    # The outer layer carries the aggregate name (here "corechannel") and the
+    # inner layer holds the actual node/resource_node lists.
+    snapshots = []
+    async for msg in _iter_messages_dedup(client, message_filter):
+        content = msg.get("content") or {}
+        if content.get("key") != "corechannel":
+            continue
+
+        if not _is_eth_confirmed(msg):
+            continue
+
+        ts = _normalize_ts_to_seconds(msg.get("time"))
+        if ts is None:
+            continue
+
+        inner = content.get("content") or {}
+        nodes_list          = inner.get("nodes", [])
+        resource_nodes_list = inner.get("resource_nodes", [])
+
+        nodes_dict          = {n["hash"]: n  for n  in nodes_list}
+        resource_nodes_dict = {rn["hash"]: rn for rn in resource_nodes_list}
+
+        snapshots.append((ts, nodes_dict, resource_nodes_dict,
+                          msg.get("item_hash")))
+    return snapshots
+
+
 async def fetch_node_snapshots(
     api_server, start_time, end_time, sender=None, out_hashes=None,
 ):
@@ -431,8 +483,14 @@ async def fetch_node_snapshots(
     Fetch historical corechannel aggregate snapshots for the period via
     the SDK's auto-paginated message iterator.
 
-    Fetches from 1 day before start_time to ensure we have a snapshot
-    before the first expense.
+    Fetches from 1 day before start_time, then guarantees a *boundary*
+    snapshot — the latest one with `ts <= start_time` — by walking back
+    day-by-day (up to `_SNAPSHOT_BOUNDARY_LOOKBACK_DAYS`) when the
+    default lookback has none, e.g. after a corechannel publisher
+    outage. Only that single boundary snapshot is added, mirroring
+    aleph-api-credit's `loadSnapshotsForRange` minimal covering set.
+    Without it, `_apply_expenses_to_snapshots` drops every expense
+    billed before the first snapshot in range.
 
     Returns:
         List of (ts, nodes_dict, resource_nodes_dict) sorted by ts, where
@@ -449,48 +507,45 @@ async def fetch_node_snapshots(
     if sender is None:
         sender = settings.status_sender
 
-    snapshots = []
-    # SDK 1.4.0 rejects bare `int` in start_date/end_date; cast to float.
-    message_filter = MessageFilter(
-        message_types=[MessageType.aggregate],
-        addresses=[sender],
-        start_date=float(start_time - 86400),
-        end_date=float(end_time),
-    )
-
-    # AGGREGATE messages on Aleph wrap their body in two `content` layers:
-    #   msg["content"] = {"key": "<name>", "content": {<body>}, ...}
-    # The outer layer carries the aggregate name (here "corechannel") and the
-    # inner layer holds the actual node/resource_node lists.
     async with _aleph_client(api_server) as client:
-        async for msg in _iter_messages_dedup(client, message_filter):
-            content = msg.get("content") or {}
-            if content.get("key") != "corechannel":
-                continue
+        snapshots = await _fetch_snapshots_between(
+            client, sender, start_time - 86400, end_time,
+        )
 
-            if not _is_eth_confirmed(msg):
-                continue
+        if not any(ts <= start_time for ts, _, _, _ in snapshots):
+            for day in range(1, _SNAPSHOT_BOUNDARY_LOOKBACK_DAYS + 1):
+                older = await _fetch_snapshots_between(
+                    client, sender,
+                    start_time - (day + 1) * 86400,
+                    start_time - day * 86400,
+                )
+                older = [s for s in older if s[0] <= start_time]
+                if older:
+                    boundary = max(older, key=lambda s: s[0])
+                    snapshots.append(boundary)
+                    LOGGER.info(
+                        "Boundary snapshot found %d day(s) back "
+                        "(ts=%.0f <= start_time=%.0f)",
+                        day + 1, boundary[0], start_time,
+                    )
+                    break
+            else:
+                LOGGER.warning(
+                    "No boundary snapshot (ts <= start_time=%.0f) found "
+                    "within %d extra lookback days; expenses billed before "
+                    "the first available snapshot will be skipped",
+                    start_time, _SNAPSHOT_BOUNDARY_LOOKBACK_DAYS,
+                )
 
-            ts = _normalize_ts_to_seconds(msg.get("time"))
-            if ts is None:
-                continue
+    if out_hashes is not None:
+        for _, _, _, h in snapshots:
+            if h:
+                out_hashes.append(h)
 
-            inner = content.get("content") or {}
-            nodes_list          = inner.get("nodes", [])
-            resource_nodes_list = inner.get("resource_nodes", [])
-
-            nodes_dict          = {n["hash"]: n  for n  in nodes_list}
-            resource_nodes_dict = {rn["hash"]: rn for rn in resource_nodes_list}
-
-            snapshots.append((ts, nodes_dict, resource_nodes_dict))
-            if out_hashes is not None:
-                h = msg.get("item_hash")
-                if h:
-                    out_hashes.append(h)
-
-    snapshots.sort(key=lambda x: x[0])
-    LOGGER.info(f"Fetched {len(snapshots)} node status snapshots")
-    return snapshots
+    result = [(ts, nodes, rnodes) for ts, nodes, rnodes, _ in snapshots]
+    result.sort(key=lambda x: x[0])
+    LOGGER.info(f"Fetched {len(result)} node status snapshots")
+    return result
 
 
 def _build_crn_to_ccn_map(nodes):

--- a/src/aleph_nodestatus/credit_extraction.py
+++ b/src/aleph_nodestatus/credit_extraction.py
@@ -98,7 +98,7 @@ async def process_credit_extraction(
     tokens: Tuple[str, ...] = (),
     max_amounts: Optional[Mapping[str, Decimal]] = None,
     min_amounts: Optional[Mapping[str, Decimal]] = None,
-    max_price_impact_bps: int = 0,
+    max_price_impact_bps: Optional[int] = None,
     fork_rpc: Optional[str] = None,
     reconcile_bps: int = 200,
 ) -> int:

--- a/src/aleph_nodestatus/ethereum.py
+++ b/src/aleph_nodestatus/ethereum.py
@@ -125,7 +125,13 @@ async def transfer_tokens(targets, metadata=None):
     max_fee, max_priority = get_gas_info(w3)
 
     if NONCE is None:
-        NONCE = w3.eth.get_transaction_count(account.address)
+        # "pending" (not the default "latest") so a still-unmined batch this
+        # signer already broadcast — e.g. a prior distribution that crashed
+        # after broadcast, before publishing — is counted, and this run signs
+        # the next nonce instead of reusing/colliding with it. Pairs with the
+        # pre-flight nonce-continuity guard in commands.py, which also reads
+        # "pending".
+        NONCE = w3.eth.get_transaction_count(account.address, "pending")
     tx_hash = None
     # Capture the nonce this batch is signed with so the published distribution
     # records it; the next run's pre-flight guard reads it back to detect any

--- a/src/aleph_nodestatus/payment_processor.py
+++ b/src/aleph_nodestatus/payment_processor.py
@@ -12,7 +12,11 @@ from eth_abi import encode as abi_encode
 from eth_utils import keccak
 from web3 import Web3
 
-from .price_oracle import CreditApiUnavailable, fair_aleph_rate
+from .price_oracle import (
+    CreditApiUnavailable,
+    TokenNotPriced,
+    fair_aleph_rate,
+)
 from .settings import settings
 
 LOGGER = logging.getLogger(__name__)
@@ -619,7 +623,7 @@ def extract_aleph(
     token_filter: Optional[Set[str]] = None,
     max_amounts: Optional[Mapping[str, Decimal]] = None,
     min_amounts: Optional[Mapping[str, Decimal]] = None,
-    max_price_impact_bps: int = 0,
+    max_price_impact_bps: Optional[int] = None,
 ) -> dict:
     """Run process() per token in settings.process_tokens. Returns the
     extract block for the audit post.
@@ -638,12 +642,15 @@ def extract_aleph(
 
     Auto-sizing (price-impact aware):
 
-    - `max_price_impact_bps`: when > 0, the loop probes the quoter at a
-      small-size reference amount and at the candidate (post-cap)
-      amount, derives the implied price impact, and bisects down until
-      the impact fits. The leftover stays in the contract for the next
-      cron cycle. 0 disables the search and falls back to the cap/min
-      behaviour above.
+    - `max_price_impact_bps`: the impact ceiling (bps) the sizing loop
+      bisects the swap amount to stay under — it probes the quoter at a
+      small-size reference amount and at the candidate (post-cap) amount,
+      derives the implied price impact, and bisects down until it fits.
+      The leftover stays in the contract for the next cron cycle. `None`
+      (the default) uses `settings.extract_max_price_impact_bps`; an
+      explicit value is honoured verbatim, so `0` means zero-tolerance
+      (only a zero-impact swap passes), NOT "disabled" — the sizing loop
+      always runs for swap tokens.
     """
     aleph_address = aleph_address or _aleph_token_address()
     effective_slippage = (
@@ -782,6 +789,16 @@ def extract_aleph(
             if settings.extract_price_deviation_enabled:
                 try:
                     fair_rate = fair_aleph_rate(token_symbol)
+                except TokenNotPriced as e:
+                    # This token alone is missing from the price map; skip it
+                    # (can't run the deviation guard without a fair rate) but
+                    # keep extracting the others, instead of aborting the run.
+                    LOGGER.warning(
+                        "Token %s absent from Credit-API price map; skipping "
+                        "this token for the run: %r", token_symbol, e,
+                    )
+                    entry["skipped_reason"] = "token_not_priced"
+                    continue
                 except CreditApiUnavailable:
                     raise
                 except Exception as e:
@@ -804,7 +821,11 @@ def extract_aleph(
                 spot_rate=spot_rate,
                 pool_fee_bps=fee_bps,
                 max_deviation_bps=settings.extract_max_deviation_bps,
-                max_impact_bps=max_price_impact_bps or settings.extract_max_price_impact_bps,
+                max_impact_bps=(
+                    settings.extract_max_price_impact_bps
+                    if max_price_impact_bps is None
+                    else max_price_impact_bps
+                ),
                 dev_pct=dev_pct,
                 is_stable=is_stable,
             )

--- a/src/aleph_nodestatus/price_oracle.py
+++ b/src/aleph_nodestatus/price_oracle.py
@@ -24,10 +24,12 @@ The map is cached for the process lifetime (one HTTP call per run; the
 extract job is a one-shot cron). The guard runs only for non-ALEPH input
 tokens (ALEPH has no swap).
 
-Failure is fail-closed: if the API is unavailable, or a required symbol
-is missing, the caller skips the token for that run. Synchronous
-`requests` is correct here - the whole extract path runs inside
-`asyncio.to_thread`, matching the module's sync web3 calls.
+Failure is fail-closed, with two granularities: a transport failure or a
+map missing the ALEPH reference raises CreditApiUnavailable and aborts the
+whole run (nothing can be priced); a single input token absent from an
+otherwise-healthy map raises TokenNotPriced and skips only that token for
+the run. Synchronous `requests` is correct here - the whole extract path
+runs inside `asyncio.to_thread`, matching the module's sync web3 calls.
 """
 
 import logging
@@ -44,7 +46,23 @@ LOGGER = logging.getLogger(__name__)
 
 class CreditApiUnavailable(RuntimeError):
     """Raised when the Credit-API fair price cannot be obtained and the
-    extract run must abort (the price is essential to sizing)."""
+    extract run must abort (the price is essential to sizing). Reserved for
+    run-wide failures — a transport error, or a price map missing the ALEPH
+    reference every token is priced against. For a single input token that
+    is absent from an otherwise-healthy map, use TokenNotPriced instead."""
+
+
+class TokenNotPriced(RuntimeError):
+    """Raised when one input token is absent from an otherwise-reachable
+    Credit-API price map. Unlike CreditApiUnavailable this is a per-token
+    condition: the caller skips only that token for the run and keeps
+    extracting the rest, rather than aborting the whole run."""
+
+    def __init__(self, symbol: str):
+        super().__init__(
+            f"token {symbol!r} is absent from the Credit-API price map"
+        )
+        self.symbol = symbol
 
 
 @dataclass
@@ -86,9 +104,20 @@ def fair_aleph_rate(token_in_symbol: str) -> float:
     """ALEPH-wei per input-wei (bonus-free) from the cached bulk price map.
 
     The credit unit cancels in the ratio, so no constants/decimals enter.
-    Raises on HTTP/parse/missing-symbol; caller converts to an abort.
+    Raises CreditApiUnavailable on a transport/parse failure or a map with
+    no ALEPH reference (run-wide); raises TokenNotPriced when only
+    `token_in_symbol` is missing (per-token skip). See the two exception
+    classes for the caller's differing responses.
     """
     prices = _price_map(settings.credit_api_blockchain)
+    if "ALEPH" not in prices:
+        # No ALEPH reference means nothing can be priced — a run-wide
+        # failure, not a per-token skip.
+        raise CreditApiUnavailable(
+            "Credit-API price map is missing the ALEPH reference rate"
+        )
+    if token_in_symbol not in prices:
+        raise TokenNotPriced(token_in_symbol)
     rate_in = _rate_credits_per_wei(prices, token_in_symbol)
     rate_aleph = _rate_credits_per_wei(prices, "ALEPH")
     if rate_aleph <= 0:

--- a/src/aleph_nodestatus/settings.py
+++ b/src/aleph_nodestatus/settings.py
@@ -225,15 +225,16 @@ class Settings(BaseSettings):
     # for the on-chain price-impact check in the extract sizing loop.
     extract_v4_stateview_address: str     = "0x7ffe42c4a5deea5b0fec41c94c136cf115597227"
 
-    # Auto-sizing of the swap input to stay under a self-impact ceiling.
-    # When > 0 (in bps), the extractor probes the configured quoter at a
-    # small-size "unit" amount and at the candidate swap amount, derives
-    # the implied price impact, and bisects downward until the impact
-    # fits within the threshold (or no amount above the per-token
-    # `--min-amount` floor fits, in which case the token is skipped).
-    # The leftover stays in the contract for the next cron cycle, giving
-    # arbitrage bots time to rebalance the pool. 0 disables the search;
-    # 100 = 1% impact ceiling, sized to absorb USDC/ETH pool depth on
+    # Auto-sizing of the swap input to stay under a self-impact ceiling
+    # (bps). The extractor probes the configured quoter at a small-size
+    # "unit" amount and at the candidate swap amount, derives the implied
+    # price impact, and bisects downward until the impact fits within this
+    # ceiling (or no amount above the per-token `--min-amount` floor fits,
+    # in which case the token is skipped). The leftover stays in the
+    # contract for the next cron cycle, giving arbitrage bots time to
+    # rebalance the pool. The sizing loop ALWAYS runs for swap tokens: a
+    # value of 0 means zero-tolerance (only a zero-impact swap passes), not
+    # "disabled"; 100 = 1% ceiling, sized to absorb USDC/ETH pool depth on
     # the configured Uniswap paths. CLI flag `--max-price-impact-bps`
     # overrides for one-off ops runs.
     extract_max_price_impact_bps: int     = 200

--- a/src/aleph_nodestatus/settings.py
+++ b/src/aleph_nodestatus/settings.py
@@ -135,6 +135,15 @@ class Settings(BaseSettings):
     process_ttl_seconds: int = 1800
     process_gas_ceiling: int = 1_500_000
 
+    @field_validator("credit_dist_holder_tier_pct")
+    @classmethod
+    def _holder_tier_pct_in_range(cls, v):
+        if not 0 <= v <= 100:
+            raise ValueError(
+                f"credit_dist_holder_tier_pct must be within 0-100, got {v}"
+            )
+        return v
+
     @field_validator("process_ttl_seconds")
     @classmethod
     def _ttl_within_contract_bound(cls, v):
@@ -195,6 +204,13 @@ class Settings(BaseSettings):
     credit_dist_credit_revenue_enabled: bool = True
     credit_dist_wage_subsidy_enabled: bool   = True
     credit_dist_holder_tier_enabled: bool    = True
+    # Scales the holder_tier reward pool, 0-100 (%). 100 = full (current
+    # behaviour), 0 = nothing paid. Lets holder_tier be dialled down during
+    # its sunset (per the tokenomics) without the all-or-nothing
+    # `credit_dist_holder_tier_enabled` switch. Applied at the price so
+    # rewards, totals, and the slash accumulator all scale together. Must be
+    # mirrored by REWARDS_HOLDER_TIER_PCT in aleph-api-credit for 1:1 parity.
+    credit_dist_holder_tier_pct: int         = 100
     credit_dist_transfer_enabled: bool       = True
     credit_dist_publish_enabled: bool        = True
 

--- a/src/aleph_nodestatus/settings.py
+++ b/src/aleph_nodestatus/settings.py
@@ -199,9 +199,18 @@ class Settings(BaseSettings):
     credit_dist_publish_enabled: bool        = True
 
     # === Slashing feature flags (CRN inactivity penalty) ===
+    # Per docs/specs/2026-06-17-crn-slashing-design.md the penalty is meant to
+    # be "default on" across all three CRN reward streams. credit_revenue and
+    # holder_tier were previously shipped as False, which disabled the penalty
+    # exactly where inactive CRNs actually accrue rewards (the execution_crn
+    # 60% share on the credit_revenue stream). wage_subsidy already excludes
+    # low-score CRNs at source, so with only it enabled the feature was a
+    # no-op. All three are now on so an inactive CRN's share is withheld from
+    # the on-chain payout (published `rewards` stay full — parity with
+    # aleph-api-credit's calculation is preserved; only the transfer differs).
     credit_dist_slash_enabled: bool        = True   # master kill switch
-    credit_dist_slash_credit_revenue: bool = False
-    credit_dist_slash_holder_tier: bool    = False
+    credit_dist_slash_credit_revenue: bool = True
+    credit_dist_slash_holder_tier: bool    = True
     credit_dist_slash_wage_subsidy: bool   = True
     credit_dist_slash_threshold_days: int  = 3
     credit_dist_slash_retroactive: bool    = True   # default: retroactive (whole period since last distribution)

--- a/src/aleph_nodestatus/status.py
+++ b/src/aleph_nodestatus/status.py
@@ -1,5 +1,4 @@
 import asyncio
-import random
 from collections import deque
 from urllib.parse import urlparse
 from multiaddr import Multiaddr
@@ -35,7 +34,17 @@ EDITABLE_FIELDS = [
 
 async def prepare_items(item_type, iterator):
     async for height, item in iterator:
-        yield (height, random.random(), (item_type, item))
+        # Tiebreaker for items sharing a block height. For Aleph messages, prefer
+        # the inner content.time (when the user signed) over the envelope time, and
+        # use item_hash as a final deterministic tiebreaker. Non-message items
+        # (balance/contract tuples) sort first with (0, "").
+        if isinstance(item, dict):
+            inner = item.get("content") if isinstance(item.get("content"), dict) else None
+            msg_time = (inner or {}).get("time", item.get("time")) or 0
+            tiebreak = (msg_time, item.get("item_hash", ""))
+        else:
+            tiebreak = (0, "")
+        yield (height, tiebreak, (item_type, item))
         
 def is_block_in_discarded_scores_range(height):
     for start, end in settings.scores_discard_periods:

--- a/tests/test_credit_distribution_refactor.py
+++ b/tests/test_credit_distribution_refactor.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import pytest
 
@@ -7,6 +8,7 @@ from aleph_nodestatus.credit_distribution import (
     UNALLOCATED_NO_ACTIVE_CCNS,
     _distribute_expense,
     _empty_unallocated,
+    _validate_hold_aggregates,
     compute_rewards,
 )
 
@@ -689,3 +691,227 @@ def test_compute_rewards_holder_tier_off_ignores_hold_field(monkeypatch):
     ))
     assert result["holder_tier"][0] == {}
     assert result["holder_tier"][1]["execution_total_aleph"] == 0
+
+
+# ---------------------------------------------------------------------
+# _validate_hold_aggregates — v1 (per-FILE hold lines) vs v2 storage
+# expenses (per-ADDRESS aggregated hold entries carrying `count`).
+# ---------------------------------------------------------------------
+
+_CD_LOGGER = "aleph_nodestatus.credit_distribution"
+
+
+def _hold_count_warnings(caplog):
+    return [r.message for r in caplog.records
+            if "hold count mismatch" in r.message]
+
+
+def _hold_amount_warnings(caplog):
+    return [r.message for r in caplog.records
+            if "hold amount mismatch" in r.message]
+
+
+def _v2_storage_expense(**overrides):
+    """v2 aggregated storage expense: 3 files spread over 2 addresses.
+
+    `stats.hold` keeps per-FILE semantics (count = number of FILES),
+    while `hold[]` has one entry per ADDRESS with a `count` field.
+    """
+    expense = {
+        "version": 2,
+        "start_date": 1.0,
+        "end_date": 1.5,
+        "credit_price_aleph": 0.001,
+        "credits": [
+            {"amount": 1000, "count": 2, "size": 200.0, "time": 7200,
+             "address": "0xU1", "ref": "storage"},
+        ],
+        "hold": [
+            {"amount": 300, "count": 2, "size": 100.0, "time": 3600,
+             "address": "0xH1", "ref": "storage"},
+            {"amount": 200, "count": 1, "size": 50.0, "time": 1800,
+             "address": "0xH2", "ref": "storage"},
+        ],
+        "stats": {
+            "hold": {"count": 3, "amount": 500},
+        },
+        "credit_price_usdc": 0.01,
+    }
+    expense.update(overrides)
+    return expense
+
+
+def test_validate_hold_v1_matching_count_no_warning(caplog):
+    """v1: declared count is compared against len(hold) — unchanged."""
+    expense = {
+        "hold": [
+            {"amount": 300, "node_id": "r1", "address": "0xH1"},
+            {"amount": 200, "node_id": "r1", "address": "0xH2"},
+        ],
+        "stats": {"hold": {"count": 2, "amount": 500}},
+    }
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == []
+    assert _hold_amount_warnings(caplog) == []
+
+
+def test_validate_hold_v1_count_mismatch_warns(caplog):
+    expense = {
+        "hold": [{"amount": 500, "node_id": "r1", "address": "0xH1"}],
+        "stats": {"hold": {"count": 3, "amount": 500}},
+    }
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == [
+        "hold count mismatch: declared=3, actual=1"
+    ]
+
+
+def test_validate_hold_v2_aggregated_counts_no_warning(caplog):
+    """v2: stats.hold.count (per-FILE) must be checked against
+    sum(hold[].count), not len(hold) — 3 files over 2 addresses."""
+    expense = _v2_storage_expense()
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == []
+    assert _hold_amount_warnings(caplog) == []
+
+
+def test_validate_hold_v2_tampered_declared_count_warns(caplog):
+    expense = _v2_storage_expense(
+        stats={"hold": {"count": 7, "amount": 500}},
+    )
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == [
+        "hold count mismatch: declared=7, actual=3"
+    ]
+
+
+def test_validate_hold_v2_entry_missing_count_warns(caplog):
+    """A v2 entry without `count` contributes 0 to the actual sum, so
+    the check under-counts and keeps warning (observability only —
+    documented behavior, mirrors the aleph-api-credit TS port)."""
+    expense = _v2_storage_expense(
+        hold=[
+            {"amount": 300, "count": 2, "size": 100.0, "time": 3600,
+             "address": "0xH1", "ref": "storage"},
+            {"amount": 200, "size": 50.0, "time": 1800,
+             "address": "0xH2", "ref": "storage"},
+        ],
+    )
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == [
+        "hold count mismatch: declared=3, actual=2"
+    ]
+
+
+@pytest.mark.parametrize("version", [2, 2.0, 3, "2"])
+def test_validate_hold_v2_version_variants_use_count_sum(version, caplog):
+    """Numeric versions >= 2 — including a numeric string, which the JS
+    `>=` in the TS port would coerce at runtime — select the v2
+    count-sum semantics instead of crashing on a str/int comparison."""
+    expense = _v2_storage_expense(version=version)
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == []
+
+
+@pytest.mark.parametrize("version", ["beta", {}, [], ""])
+def test_validate_hold_junk_version_falls_back_to_v1(version, caplog):
+    """A non-numeric version must not abort the run (observability-only
+    check); it falls back to v1 len() semantics. Discriminator: 2
+    entries with count=5 each and declared=2 — v1 (len=2) is silent,
+    v2 (sum=10) would warn."""
+    expense = {
+        "version": version,
+        "hold": [
+            {"amount": 300, "count": 5, "address": "0xH1"},
+            {"amount": 200, "count": 5, "address": "0xH2"},
+        ],
+        "stats": {"hold": {"count": 2, "amount": 500}},
+    }
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == []
+
+
+def test_validate_hold_v2_non_numeric_count_no_crash(caplog):
+    """A v2 entry whose count is a string contributes 0 (same as a
+    missing count) instead of raising TypeError inside sum()."""
+    expense = _v2_storage_expense(
+        hold=[
+            {"amount": 300, "count": "2", "size": 100.0, "time": 3600,
+             "address": "0xH1", "ref": "storage"},
+            {"amount": 200, "count": 1, "size": 50.0, "time": 1800,
+             "address": "0xH2", "ref": "storage"},
+        ],
+    )
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == [
+        "hold count mismatch: declared=3, actual=1"
+    ]
+
+
+def test_validate_hold_v2_amount_check_unchanged(caplog):
+    """v2 per-address amounts sum to the same declared total, so the
+    amount check needs no version awareness — and still fires when the
+    declared total is off by more than 1."""
+    expense = _v2_storage_expense(
+        stats={"hold": {"count": 3, "amount": 999}},
+    )
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        _validate_hold_aggregates(expense)
+    assert _hold_count_warnings(caplog) == []
+    assert _hold_amount_warnings(caplog) == [
+        "hold amount mismatch: declared=999, actual=500"
+    ]
+
+
+def test_compute_rewards_v2_storage_hold_no_spurious_warning(
+    monkeypatch, caplog,
+):
+    """End-to-end: a v2 aggregated storage expense flows through
+    compute_rewards with holder tier on — hold amounts distribute and
+    the validator raises no count warning."""
+    msg = {
+        "item_hash": "h-v2",
+        "time": 1.6,
+        "confirmations": [{"chain": "ETH", "height": 100}],
+        "content": {
+            "tags": ["credit_expense", "type_storage"],
+            "expense": _v2_storage_expense(),
+        },
+    }
+
+    async def fake_fetch_msgs(*a, **kw):
+        return [msg]
+
+    async def fake_fetch_snaps(*a, **kw):
+        return [(1.0, {"n1": _node("n1", 0.9, {"0xS1": 100})}, {})]
+
+    monkeypatch.setattr(
+        "aleph_nodestatus.credit_distribution._fetch_expense_messages",
+        fake_fetch_msgs,
+    )
+    monkeypatch.setattr(
+        "aleph_nodestatus.credit_distribution.fetch_node_snapshots",
+        fake_fetch_snaps,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=_CD_LOGGER):
+        result = asyncio.run(compute_rewards(
+            start_time=1.0, end_time=2.0,
+            include_holder_tier=True,
+        ))
+
+    assert _hold_count_warnings(caplog) == []
+    assert _hold_amount_warnings(caplog) == []
+    _, credit_totals = result["credit_revenue"]
+    _, holder_totals = result["holder_tier"]
+    # credits: 1000 * 0.001; hold: (300 + 200) * 0.001
+    assert credit_totals["storage_total_aleph"] == pytest.approx(1.0)
+    assert holder_totals["storage_total_aleph"] == pytest.approx(0.5)

--- a/tests/test_credit_distribution_refactor.py
+++ b/tests/test_credit_distribution_refactor.py
@@ -519,6 +519,53 @@ def test_compute_rewards_holder_tier_processes_hold_field(monkeypatch):
     assert holder["0xCRN1"] == pytest.approx(0.30)
 
 
+def test_holder_tier_pct_scales_only_holder_pool(monkeypatch):
+    """credit_dist_holder_tier_pct dials the holder_tier pool down without
+    touching credit_revenue. At 25%, holder amounts are quartered; credits
+    are unchanged."""
+    from aleph_nodestatus.settings import settings
+    monkeypatch.setattr(settings, "credit_dist_holder_tier_pct", 25)
+
+    expense = {
+        "credit_price_aleph": 0.001,
+        "credits": [{"amount": 1000, "node_id": "r1", "address": "0xU1"}],
+        "hold":    [{"amount":  500, "node_id": "r1", "address": "0xH1"}],
+        "hold_amount": 500, "hold_count": 1,
+    }
+    msg = {
+        "item_hash": "h1", "time": 1.5,
+        "confirmations": [{"chain": "ETH", "height": 100}],
+        "content": {"tags": ["credit_expense", "type_execution"],
+                    "expense": expense},
+    }
+
+    async def fake_fetch_msgs(*a, **kw): return [msg]
+    async def fake_fetch_snaps(*a, **kw):
+        return [(1.0, {"n1": _node("n1", 0.9, {"0xS1": 100},
+                                   resource_nodes=["r1"])},
+                     {"r1": _rnode("r1", 0.9, "0xCRN1")})]
+
+    monkeypatch.setattr(
+        "aleph_nodestatus.credit_distribution._fetch_expense_messages",
+        fake_fetch_msgs)
+    monkeypatch.setattr(
+        "aleph_nodestatus.credit_distribution.fetch_node_snapshots",
+        fake_fetch_snaps)
+
+    result = asyncio.run(compute_rewards(
+        start_time=1.0, end_time=2.0, web3=_W3, include_holder_tier=True))
+
+    credit, credit_totals = result["credit_revenue"]
+    holder, holder_totals = result["holder_tier"]
+
+    # credit_revenue untouched
+    assert credit_totals["execution_total_aleph"] == pytest.approx(1.0)
+    assert credit["0xCRN1"] == pytest.approx(0.60)
+    # holder_tier scaled to 25%: pool 0.5 -> 0.125, CRN 0.30 -> 0.075
+    assert holder_totals["execution_total_aleph"] == pytest.approx(0.125)
+    assert holder["0xCRN1"] == pytest.approx(0.075)
+
+
 def test_full_resync_applies_expenses_past_last_state_machine_yield(monkeypatch):
     """`_compute_rewards_full_resync` builds one snapshot per state-machine
     tick (paired with the tick's ETH block timestamp) and then routes

--- a/tests/test_nonce_guard.py
+++ b/tests/test_nonce_guard.py
@@ -15,7 +15,11 @@ if "plyvel" not in sys.modules:
     _plyvel_stub.DB = object
     sys.modules["plyvel"] = _plyvel_stub
 
-from aleph_nodestatus.commands import max_successful_nonce, nonce_gap_reason
+from aleph_nodestatus.commands import (
+    max_successful_nonce,
+    nonce_gap_reason,
+    signer_next_nonce,
+)
 
 
 def _dist(*nonces_success):
@@ -97,3 +101,31 @@ class TestNonceGapReason:
         )
         # but current 50 with resolved max 42 -> gap blocked
         assert nonce_gap_reason(50, c, get_tx_nonce=lambda _tx: 42) is not None
+
+
+class TestSignerNextNonce:
+    """The guard must read the PENDING nonce, not 'latest'. A batchTransfer a
+    prior run broadcast but that has not yet mined is only visible under
+    'pending'; reading 'latest' would miss it and let a rerun double-pay."""
+
+    class _Eth:
+        def __init__(self):
+            self.calls = []
+
+        def get_transaction_count(self, address, block_identifier=None):
+            self.calls.append((address, block_identifier))
+            return 7
+
+    class _Web3:
+        def __init__(self):
+            self.eth = TestSignerNextNonce._Eth()
+
+        @staticmethod
+        def to_checksum_address(addr):
+            return addr
+
+    def test_reads_pending_not_latest(self):
+        w3 = self._Web3()
+        assert signer_next_nonce(w3, "0xABC") == 7
+        # exactly one read, and it must pass the "pending" tag
+        assert w3.eth.calls == [("0xABC", "pending")]

--- a/tests/test_payment_processor.py
+++ b/tests/test_payment_processor.py
@@ -304,6 +304,128 @@ def test_extract_aleph_slippage_bps_override(monkeypatch):
     assert int(usdc_entry["min_out"]) == 9_500_000
 
 
+def _capture_impact_ceiling(monkeypatch):
+    """Shadow the sizing loop with a stub that records the max_impact_bps it
+    was handed, and return the recording list."""
+    import aleph_nodestatus.payment_processor as pp
+    seen = []
+
+    def _stub(*a, **k):
+        seen.append(k["max_impact_bps"])
+        return {
+            "settled_amount_in": k["upper_amount_in"],
+            "iterations": [],
+            "binding": None,
+        }
+
+    monkeypatch.setattr(pp, "bisect_swap_amount", _stub)
+    return seen
+
+
+def _run_extract_with_impact(monkeypatch, max_price_impact_bps):
+    w3 = MagicMock()
+    w3.to_checksum_address = lambda x: x
+    w3.eth.get_balance.return_value = 1_000_000
+    processor = _mk_extract_processor(is_stable=False)
+    quoters = _mk_quoters_v3(call_return_value=(10_000, [0], [0], 0))
+    erc20_mock = MagicMock()
+    erc20_mock.functions.balanceOf.return_value.call.return_value = 1_000_000
+    monkeypatch.setattr(
+        "aleph_nodestatus.payment_processor._erc20_contract",
+        lambda w3, addr: erc20_mock,
+    )
+    monkeypatch.setattr(
+        "aleph_nodestatus.payment_processor.simulate_process",
+        lambda *a, **kw: None,
+    )
+    extract_aleph(
+        w3, processor, quoters, account=None,
+        from_address="0xC870B0Ca4B3d65f33E2a3c732ab3cD2aE555b14E",
+        dry_run=True,
+        max_price_impact_bps=max_price_impact_bps,
+    )
+
+
+def test_extract_aleph_impact_zero_is_zero_tolerance(monkeypatch):
+    """An explicit max_price_impact_bps=0 must reach the sizing loop as 0
+    (zero-tolerance), NOT be coerced back to the settings default."""
+    seen = _capture_impact_ceiling(monkeypatch)
+    _run_extract_with_impact(monkeypatch, max_price_impact_bps=0)
+    assert seen  # at least one swap token was sized
+    assert all(v == 0 for v in seen)
+
+
+def test_extract_aleph_impact_none_uses_settings_default(monkeypatch):
+    """max_price_impact_bps=None resolves to settings.extract_max_price_impact_bps."""
+    from aleph_nodestatus.settings import settings
+    seen = _capture_impact_ceiling(monkeypatch)
+    _run_extract_with_impact(monkeypatch, max_price_impact_bps=None)
+    assert seen
+    assert all(v == settings.extract_max_price_impact_bps for v in seen)
+
+
+def _mk_extract_env(monkeypatch):
+    """Common w3/processor/quoters/erc20 wiring for the price-failure tests."""
+    w3 = MagicMock()
+    w3.to_checksum_address = lambda x: x
+    w3.eth.get_balance.return_value = 1_000_000
+    processor = _mk_extract_processor(is_stable=False)
+    quoters = _mk_quoters_v3(call_return_value=(10_000, [0], [0], 0))
+    erc20_mock = MagicMock()
+    erc20_mock.functions.balanceOf.return_value.call.return_value = 1_000_000
+    monkeypatch.setattr(
+        "aleph_nodestatus.payment_processor._erc20_contract",
+        lambda w3, addr: erc20_mock,
+    )
+    monkeypatch.setattr(
+        "aleph_nodestatus.payment_processor.simulate_process",
+        lambda *a, **kw: None,
+    )
+    return w3, processor, quoters
+
+
+def test_extract_aleph_token_not_priced_skips_only_that_token(monkeypatch):
+    """A TokenNotPriced from the fair-rate lookup skips that token and lets the
+    run finish, instead of aborting every remaining token."""
+    import aleph_nodestatus.payment_processor as pp
+    from aleph_nodestatus.price_oracle import TokenNotPriced
+
+    def _raise(symbol):
+        raise TokenNotPriced(symbol)
+
+    monkeypatch.setattr(pp, "fair_aleph_rate", _raise)
+    w3, processor, quoters = _mk_extract_env(monkeypatch)
+
+    # Does not raise — the run completes.
+    result = extract_aleph(
+        w3, processor, quoters, account=None,
+        from_address="0xC870B0Ca4B3d65f33E2a3c732ab3cD2aE555b14E",
+        dry_run=True,
+    )
+    skipped = [e for e in result["tokens"]
+               if e["skipped_reason"] == "token_not_priced"]
+    assert skipped, "expected the unpriced swap token(s) to be skipped"
+
+
+def test_extract_aleph_credit_api_unavailable_aborts(monkeypatch):
+    """A run-wide CreditApiUnavailable still propagates out (abort the run)."""
+    import aleph_nodestatus.payment_processor as pp
+    from aleph_nodestatus.price_oracle import CreditApiUnavailable
+
+    def _raise(symbol):
+        raise CreditApiUnavailable("credit api down")
+
+    monkeypatch.setattr(pp, "fair_aleph_rate", _raise)
+    w3, processor, quoters = _mk_extract_env(monkeypatch)
+
+    with pytest.raises(CreditApiUnavailable):
+        extract_aleph(
+            w3, processor, quoters, account=None,
+            from_address="0xC870B0Ca4B3d65f33E2a3c732ab3cD2aE555b14E",
+            dry_run=True,
+        )
+
+
 def test_extract_aleph_unsupported_swap_config_is_explicit(monkeypatch, caplog):
     """A v2/v3 swap config makes pool_spot_rate raise NotImplementedError.
     That is a config/code mismatch, not a transient read failure: it must

--- a/tests/test_prepare_items_ordering.py
+++ b/tests/test_prepare_items_ordering.py
@@ -1,0 +1,72 @@
+"""
+Regression test for the link-ordering bug.
+
+Previously `prepare_items` used `random.random()` as the tiebreaker within a block,
+so several `corechan-operation` messages confirmed in the same Ethereum block would
+be processed in a random order on every run. When a `link` op happened to be merged
+ahead of its `create-node`, the link's precondition (`address in self.address_nodes`)
+failed and the link was silently dropped — non-deterministically wiping CCN/CRN
+linkage on each replay.
+
+The fix: tiebreak deterministically on (message_time, item_hash).
+"""
+import asyncio
+
+from aleph_nodestatus.status import prepare_items
+from aleph_nodestatus.utils import merge
+
+
+async def _async_iter(items):
+    for it in items:
+        yield it
+
+
+# Reproduces the Apicultor incident: 7 corechan-operation messages all at the same
+# Ethereum block, ordered correctly by their content.time.
+HEIGHT = 24_992_406
+APICULTOR_OPS = [
+    {"item_hash": "crn2_create",  "time": 1.0, "content": {"time": 1_777_536_288, "address": "0x21801"}},
+    {"item_hash": "crni_create",  "time": 1.0, "content": {"time": 1_777_536_353, "address": "0x21801"}},
+    {"item_hash": "crn12_create", "time": 1.0, "content": {"time": 1_777_536_630, "address": "0x21801"}},
+    {"item_hash": "ccn_create",   "time": 1.0, "content": {"time": 1_777_537_218, "address": "0xd144f"}},
+    {"item_hash": "link_crn2",    "time": 1.0, "content": {"time": 1_777_537_490, "address": "0xd144f"}},
+    {"item_hash": "link_crni",    "time": 1.0, "content": {"time": 1_777_537_503, "address": "0xd144f"}},
+    {"item_hash": "link_crn12",   "time": 1.0, "content": {"time": 1_777_537_526, "address": "0xd144f"}},
+]
+
+
+async def _drain():
+    """Reproduces the real call site: each message comes from its own
+    iterator-window, all merged together. With N>1 iterators sharing a height,
+    the heap-merge tiebreaker decides ordering."""
+    iterators = [
+        prepare_items("staking-update", _async_iter([(HEIGHT, msg)]))
+        for msg in APICULTOR_OPS
+    ]
+    return [item for _, _, (_, item) in
+            [tup async for tup in merge(*iterators)]]
+
+
+def test_prepare_items_orders_deterministically_within_block():
+    """Same input yields the same output on every run."""
+    runs = [asyncio.run(_drain()) for _ in range(20)]
+    first = [m["item_hash"] for m in runs[0]]
+    for r in runs[1:]:
+        assert [m["item_hash"] for m in r] == first, (
+            "prepare_items + merge produced different orderings across runs — "
+            "tiebreaker is not deterministic"
+        )
+
+
+def test_prepare_items_orders_create_before_link_within_block():
+    """The CCN's create-node must be merged before any link op referencing it,
+    even though they share an Ethereum block. Determinism alone isn't enough —
+    the order must respect message content.time."""
+    out = asyncio.run(_drain())
+    order = [m["item_hash"] for m in out]
+    ccn_idx = order.index("ccn_create")
+    for link in ("link_crn2", "link_crni", "link_crn12"):
+        assert order.index(link) > ccn_idx, (
+            f"{link} merged before ccn_create — link precondition would fail "
+            f"and the linkage would be silently dropped"
+        )

--- a/tests/test_price_oracle.py
+++ b/tests/test_price_oracle.py
@@ -204,8 +204,29 @@ def test_fair_aleph_rate_ratio(monkeypatch):
     assert abs(rate - (1.0 / (12277 / 1e18))) / rate < 1e-9
 
 
-def test_fair_aleph_rate_missing_symbol_raises(monkeypatch):
+def test_fair_aleph_rate_missing_input_token_raises_token_not_priced(monkeypatch):
+    """Input token absent from an otherwise-healthy map (ALEPH present) is a
+    per-token condition -> TokenNotPriced, so the caller skips only that token
+    rather than aborting the whole run."""
     import aleph_nodestatus.price_oracle as po
-    monkeypatch.setattr(po, "_price_map", lambda chain: {})
-    with pytest.raises(Exception):
+    fake = {
+        "ALEPH": {"tokenSymbol": "ALEPH", "tokenAmount": "1000000000000000000",
+                  "creditAmount": "14732", "creditBonusAmount": "2455"},
+    }
+    monkeypatch.setattr(po, "_price_map", lambda chain: fake)
+    with pytest.raises(po.TokenNotPriced) as exc:
+        po.fair_aleph_rate("USDC")
+    assert exc.value.symbol == "USDC"
+
+
+def test_fair_aleph_rate_missing_aleph_raises_api_unavailable(monkeypatch):
+    """No ALEPH reference means nothing can be priced -> run-wide
+    CreditApiUnavailable, not a per-token skip."""
+    import aleph_nodestatus.price_oracle as po
+    fake = {
+        "USDC": {"tokenSymbol": "USDC", "tokenAmount": "1000000",
+                 "creditAmount": "1000000", "creditBonusAmount": "0"},
+    }
+    monkeypatch.setattr(po, "_price_map", lambda chain: fake)
+    with pytest.raises(po.CreditApiUnavailable):
         po.fair_aleph_rate("USDC")

--- a/tests/test_slashing.py
+++ b/tests/test_slashing.py
@@ -1,6 +1,8 @@
 from aleph_nodestatus.slashing import is_slashable
 from aleph_nodestatus.slashing import SlashAccumulator
 from aleph_nodestatus.slashing import compute_slashing
+from aleph_nodestatus.slashing import enabled_slash_streams
+from aleph_nodestatus.settings import settings
 
 BLOCKS_PER_DAY = 7130
 
@@ -201,3 +203,19 @@ def test_wage_path_feeds_accumulator():
     assert e["post_death"] > 0          # inactive_since set
     assert e["total"] == e["post_death"]
     assert e["inactive_since"] == 42
+
+
+def test_default_flags_enable_all_three_streams():
+    """Per the slashing design ('default on'), an inactive CRN's share is
+    withheld across every reward stream. credit_revenue + holder_tier were
+    previously shipped False, which disabled the penalty exactly where
+    inactive CRNs accrue (the execution_crn share on credit_revenue) while
+    wage_subsidy — the only enabled stream — already excludes low-score CRNs
+    at source, making the feature a no-op. Guard against that regression."""
+    assert settings.credit_dist_slash_enabled is True
+    assert settings.credit_dist_slash_credit_revenue is True
+    assert settings.credit_dist_slash_holder_tier is True
+    assert settings.credit_dist_slash_wage_subsidy is True
+    assert set(enabled_slash_streams()) == {
+        "credit_revenue", "holder_tier", "wage_subsidy",
+    }

--- a/tests/test_slashing_integration.py
+++ b/tests/test_slashing_integration.py
@@ -142,6 +142,15 @@ async def test_slashing_applied_withholds_payout_and_publishes_meta(
     assert dist["slashed_meta"]["streams"] == list(
         slashing_mod.enabled_slash_streams()
     )
+    # gross total stays the full calculation (parity with aleph-api-credit)
+    assert dist["total"]["totals"]["aleph"] == sum(FINAL_REWARDS.values())  # 15.0
+    # withheld total matches the slashed map
+    assert dist["slashed_meta"]["total_aleph"] == sum(slashed.values())     # 4.0
+    # net payout = gross - slash, floored per address (0xCRN 10-4=6, 0xOther 5)
+    assert dist["payout_total_aleph"] == 11.0
+    assert dist["payout_total_aleph"] == (
+        dist["total"]["totals"]["aleph"] - dist["slashed_meta"]["total_aleph"]
+    )
 
 
 @pytest.mark.asyncio
@@ -169,6 +178,10 @@ async def test_slashing_flag_off_is_noop(patch_pipeline, monkeypatch):
     assert dist["slashed"] == {}
     assert dist["slashed_meta"]["enabled"] is False
     assert dist["slashed_meta"]["streams"] == []
+    # Nothing withheld: net payout equals the gross total.
+    assert dist["slashed_meta"]["total_aleph"] == 0
+    assert dist["payout_total_aleph"] == sum(FINAL_REWARDS.values())
+    assert dist["payout_total_aleph"] == dist["total"]["totals"]["aleph"]
 
 
 # ─────────────────── _payout_after_slash unit coverage ───────────────────

--- a/tests/test_snapshot_boundary_lookback.py
+++ b/tests/test_snapshot_boundary_lookback.py
@@ -1,0 +1,156 @@
+"""Boundary-snapshot guarantee for `fetch_node_snapshots`.
+
+Mirrors aleph-api-credit `snapshotsStore.loadSnapshotsForRange`: the
+returned set must always include the latest snapshot with
+`ts <= start_time` (the "boundary"), walking back day-by-day (up to 30
+days) past the default 1-day lookback when the near window has none —
+e.g. after a corechannel publisher outage. Without the boundary,
+`_apply_expenses_to_snapshots` silently drops every expense billed
+before the first snapshot in range.
+"""
+
+import asyncio
+
+import pytest
+
+from aleph_nodestatus import credit_distribution as cd
+
+
+START = 1_782_734_171.0   # 2026-06-29T11:56:11Z — real calc window start
+END = 1_784_890_163.0     # 2026-07-24T10:49:23Z
+DAY = 86_400.0
+
+
+def _agg_msg(ts, item_hash, confirmed=True):
+    """Minimal corechannel AGGREGATE message dict as parsed by
+    `fetch_node_snapshots` (post `_iter_messages_dedup`)."""
+    return {
+        "item_hash": item_hash,
+        "time": ts,
+        "confirmations": (
+            [{"chain": "ETH", "height": 1}] if confirmed else []
+        ),
+        "content": {
+            "key": "corechannel",
+            "content": {
+                "nodes": [{"hash": f"ccn-{item_hash}"}],
+                "resource_nodes": [{"hash": f"crn-{item_hash}"}],
+            },
+        },
+    }
+
+
+class _Client:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _install_fake_feed(monkeypatch, messages, windows):
+    """Serve `messages` filtered by each MessageFilter window; record
+    every (start_date, end_date) requested in `windows`."""
+
+    async def fake_iter(client, message_filter):
+        windows.append((message_filter.start_date, message_filter.end_date))
+        for m in messages:
+            if message_filter.start_date <= m["time"] <= message_filter.end_date:
+                yield m
+
+    monkeypatch.setattr(cd, "_aleph_client", lambda api: _Client())
+    monkeypatch.setattr(cd, "_iter_messages_dedup", fake_iter)
+
+
+def test_walks_back_for_boundary_snapshot_after_gap(monkeypatch):
+    """Publisher outage: nothing in [start-1d, start]; an older aggregate
+    exists 3.5 days before start. It must be returned as the boundary
+    (first element, ts <= start) instead of being invisible."""
+    windows = []
+    msgs = [
+        _agg_msg(START - 3.5 * DAY, "old-boundary"),
+        _agg_msg(START + 2 * DAY, "in-window-1"),
+        _agg_msg(START + 3 * DAY, "in-window-2"),
+    ]
+    _install_fake_feed(monkeypatch, msgs, windows)
+
+    snaps = asyncio.run(cd.fetch_node_snapshots("http://x", START, END))
+
+    assert len(snaps) == 3
+    assert snaps[0][0] == START - 3.5 * DAY
+    assert snaps[0][0] <= START
+    assert "ccn-old-boundary" in snaps[0][1]
+
+
+def test_no_walk_back_when_boundary_in_default_window(monkeypatch):
+    """Healthy case: a snapshot within the default 1-day lookback already
+    covers the boundary — exactly one fetch, no widening."""
+    windows = []
+    msgs = [
+        _agg_msg(START - 3_600, "near-boundary"),
+        _agg_msg(START + DAY, "in-window"),
+    ]
+    _install_fake_feed(monkeypatch, msgs, windows)
+
+    snaps = asyncio.run(cd.fetch_node_snapshots("http://x", START, END))
+
+    assert len(windows) == 1
+    assert [s[0] for s in snaps] == [START - 3_600, START + DAY]
+
+
+def test_walk_back_keeps_only_latest_confirmed_boundary(monkeypatch):
+    """The walk-back day may hold several aggregates; only the LATEST
+    ETH-confirmed one is kept (minimal covering set, mirroring
+    api-credit's single boundary snapshot)."""
+    windows = []
+    day1_start = START - 2 * DAY   # first walk-back window
+    msgs = [
+        _agg_msg(day1_start + 1_000, "older-confirmed"),
+        _agg_msg(day1_start + 5_000, "latest-confirmed"),
+        _agg_msg(day1_start + 9_000, "later-unconfirmed", confirmed=False),
+        _agg_msg(START + DAY, "in-window"),
+    ]
+    _install_fake_feed(monkeypatch, msgs, windows)
+
+    snaps = asyncio.run(cd.fetch_node_snapshots("http://x", START, END))
+
+    assert [s[0] for s in snaps] == [day1_start + 5_000, START + DAY]
+    assert "ccn-latest-confirmed" in snaps[0][1]
+
+
+def test_gives_up_after_30_walk_back_days(monkeypatch):
+    """No boundary within 30 extra days: return the in-window snapshots
+    unchanged (expenses before them keep the existing skip+warning
+    behavior, same as api-credit with an undefined boundary)."""
+    windows = []
+    msgs = [_agg_msg(START + 2 * DAY, "in-window")]
+    _install_fake_feed(monkeypatch, msgs, windows)
+
+    snaps = asyncio.run(cd.fetch_node_snapshots("http://x", START, END))
+
+    assert [s[0] for s in snaps] == [START + 2 * DAY]
+    # 1 main window + 30 walk-back days, then stop.
+    assert len(windows) == 31
+
+
+def test_boundary_hash_reported_in_out_hashes(monkeypatch):
+    """Dry-run debug: the walk-back boundary snapshot is part of the
+    consumed input set, so its hash must land in `out_hashes` — and the
+    non-boundary aggregates of the walk-back day must not."""
+    windows = []
+    day1_start = START - 2 * DAY
+    msgs = [
+        _agg_msg(day1_start + 1_000, "older-confirmed"),
+        _agg_msg(day1_start + 5_000, "latest-confirmed"),
+        _agg_msg(START + DAY, "in-window"),
+    ]
+    _install_fake_feed(monkeypatch, msgs, windows)
+
+    out_hashes = []
+    asyncio.run(cd.fetch_node_snapshots(
+        "http://x", START, END, out_hashes=out_hashes,
+    ))
+
+    assert "latest-confirmed" in out_hashes
+    assert "in-window" in out_hashes
+    assert "older-confirmed" not in out_hashes


### PR DESCRIPTION
## Summary

Guarantee the boundary snapshot (latest aggregate with `ts ≤ start_time`) when the default 1-day lookback has none—e.g. after a corechannel publisher outage. Mirror `aleph-api-credit`'s `snapshotsStore.loadSnapshotsForRange` by walking back day-by-day up to 30 days and adding only that single boundary snapshot (minimal covering set).

Without it, `_apply_expenses_to_snapshots` silently drops every expense billed before the first snapshot in range, creating **permanent unpayable amounts** that diverge cross-run from credit-api.

## Problem

On 2026-07-24, the corechannel publisher was down 2026-06-26 15:41 → 2026-06-30 10:34. The credit-distribution window started 2026-06-29 11:56, and `fetch_node_snapshots` only looked back 1 day (hardcoded `start_time - 86400`), missing all pre-outage aggregates. Result: 45 expenses (~112k ALEPH gross, ~103k allocatable) from the first 22.6 hours were silently dropped as "falls before first snapshot". The next run's window filter + dedup rule guarantee they stay unpayable forever.

credit-api paid them via at-or-before fallback over its full history, so nodestatus diverged +4% in `credit_revenue` and `holder_tier`. The wage stream was unaffected (its daily loop has fallback semantics).

## Solution

Extend snapshot boundary search:
1. Fetch [start_time - 1d, end_time] as before (default window).
2. If no snapshot `ts ≤ start_time`, walk back day-by-day for up to 30 days (matching credit-api).
3. Return the boundary snapshot found + all in-window ones (minimal covering set, no full days).
4. If no boundary after 30 days, log a warning and continue (same end-state as credit-api with undefined boundary).

Mirrors exactly `snapshotsStore.loadSnapshotsForRange` logic in aleph-api-credit/src/dal/rewards/.

## Validation (Real Data)

Before fix: 3,223,875 ALEPH, 45 "falls before first snapshot" warnings, 328 rewards.

After fix: 3,327,404 ALEPH (+103,529), 0 warnings, 330 rewards.

Boundary snapshot (26-jun 15:41, pre-outage) found via 3.5-day walk-back. Residual vs credit-api: 0.16% (credit_revenue) / 0.11% (holder_tier)—same as the stable June distribution window.